### PR TITLE
docs: fix four spelling errors in Domain-Specific Testing chapter

### DIFF
--- a/Document/content/4.0_Domain_Specific_Testing.md
+++ b/Document/content/4.0_Domain_Specific_Testing.md
@@ -1,6 +1,6 @@
 ## Chapter 4: Domain-Specific Testing
 
-The AI Testing Guide framework is structured around four core layers of a typical AI Architure:
+The AI Testing Guide framework is structured around four core layers of a typical AI Architecture:
 - Application Layer
 - Model Layer
 - Infrastructure Layer
@@ -8,7 +8,7 @@ The AI Testing Guide framework is structured around four core layers of a typica
 
 While the framework integrates these layers comprehensively, it is also possible-and often useful—to focus testing efforts on one specific domain such as Security, Privacy, RAI and Trustworthy AI (TAI). 
 
-It is useful to understand whaich test are related to Secuirty and PRivacy and which to RAI and TAI.
+It is useful to understand which test are related to Security and Privacy and which to RAI and TAI.
 
 We define the following three kind of Input for an AI System:
 


### PR DESCRIPTION
### Summary
Fixes four spelling errors in the “Domain-Specific Testing” chapter of the AI Testing Guide.

### Changes made
* “Architure” → “Architecture”
* “whaich”     → “which”
* “Secuirty”   → “Security”
* “PRivacy”    → “Privacy”

### Impact
Doc-only edit, no code or build logic touched, site still builds and renders locally with  
`bundle exec jekyll build`.

### Checklist
- [x] Changes align with project goals and improve documentation quality  
- [x] Markdown format follows project style guidelines  
- [x] No functional code changed, therefore no tests required  
- [x] Ran `codespell` against MD and passed  
- [x] Local Jekyll build completes without errors  

### Related issues
None