### PR TITLE
fix: bring Slack link

### DIFF
--- a/info.md
+++ b/info.md
@@ -5,6 +5,8 @@
 
 ### Social Links
 * [LinkedIn](https://www.linkedin.com/company/owasp-ai-testing-guide-project/)
+* [Slack channel](https://join.slack.com/t/owasp/shared_invite/zt-2xh7welj5-ueQHlFJfmFPL_TKb4LCd6Q)
+
 
 ### Code Repository
 * [GitHub](https://github.com/OWASP/www-project-ai-testing-guide)

--- a/info.md
+++ b/info.md
@@ -7,6 +7,5 @@
 * [LinkedIn](https://www.linkedin.com/company/owasp-ai-testing-guide-project/)
 * [Slack channel](https://join.slack.com/t/owasp/shared_invite/zt-2xh7welj5-ueQHlFJfmFPL_TKb4LCd6Q)
 
-
 ### Code Repository
 * [GitHub](https://github.com/OWASP/www-project-ai-testing-guide)


### PR DESCRIPTION
Commit 31bfb726d736c9ada91ba722c1e745403b75db9d removed the Slack channel link while it seemed to have been added just a few minutes before in 918b8898e178e237e007e304f8a19ec5271090d6.

The goal of this PR is to bring back the Slack channel invitation link to ease access for people motivated to contribute to the project.