### PR TITLE
Fix typo in 2.0_Threat_Modeling_for_AI_Systems.md

### DIFF
--- a/Document/content/2.0_Threat_Modeling_for_AI_Systems.md
+++ b/Document/content/2.0_Threat_Modeling_for_AI_Systems.md
@@ -3,7 +3,7 @@
 ### What is Threat Modeling?  
 Threat modeling is a structured process for identifying, quantifying, and addressing security threats to a system. It allows developers, architects, and security professionals to proactively assess how their system could be attacked and to design appropriate defenses early in the development lifecycle.  
 
-Within AI systems, threat modeling reveals emerging and sophisticated threat vectors, clarifies potential attack paths against data assets, and quantifies both technical and business impacts. These risks, spanning prompt injection to model extraction, arise from the distinctive characteristics of machine learning and generative AI technologies.
+Within AI systems, threat modeling reveals emerging and sophisticated threat vectors, clarifies potential attack paths against data assets, and quantifies both technical and business impacts. These risks, spanning from prompt injection to model extraction, arise from the distinctive characteristics of machine learning and generative AI technologies.
 
 ### Core Objectives of AI Threat Modeling  
 Threat modeling for AI systems aims to identify unique AI attack surfaces, prioritize the highest-impact risks (like adversarial and inference attacks), and guide targeted testing. It fosters secure-by-design architectures, creates a common risk language across engineering, security, and compliance teams, and provides documented evidence for regulatory due diligence. By continuously updating the threat model, organizations maintain a living risk roadmap that adapts as AI components and threats evolve.  


### PR DESCRIPTION
There's a typo in "spanning prompt injection to model extraction". Changed to "spanning from prompt injection to model extraction".