### PR TITLE
docs: fix missing and broken reference links in tab_contributing and AITG-APP-06

### DIFF
--- a/Document/content/tests/AITG-APP-06_Testing_for_Agentic_Behavior_Limits.md
+++ b/Document/content/tests/AITG-APP-06_Testing_for_Agentic_Behavior_Limits.md
@@ -174,9 +174,9 @@ In 2023, GPT-4, when tested by ARC, hired a human on TaskRabbit to solve a CAPTC
 - **Agentic Security Scanner**: An open-source tool for scanning AI systems to detect vulnerabilities related to agentic behaviors - [Link](https://www.star-history.com/blog/agentic-security)
 
 ### References
-- OWASP Top 10 for LLM – LLM06: Excessive Agency – [Link](https://genai.owasp.org/llmrisk/llm06-sensitive-information-disclosure/?utm_source=chatgpt.com)
+- OWASP Top 10 for LLM – LLM06: Excessive Agency – [Link](https://genai.owasp.org/llmrisk/llm062025-excessive-agency/)
 - AISVS - 0x10-C09-Orchestration-and-Agentic-Action - [Link](https://github.com/OWASP/AISVS/blob/main/1.0/en/0x10-C09-Orchestration-and-Agentic-Action.md)
-- OWASP Top 10 for Agentic Applications - [Link]()
+- OWASP Top 10 for Agentic Applications - [Link](https://github.com/OWASP/www-project-top-10-for-large-language-model-applications/tree/main/initiatives/agent_security_initiative/agentic-top-10)
 - ASI Agentic Exploits & Incidents Tracker - [Link](https://github.com/OWASP/www-project-top-10-for-large-language-model-applications/blob/main/initiatives/agent_security_initiative/ASI%20Agentic%20Exploits%20%26%20Incidents/ASI_Agentic_Exploits_Incidents.md)
 - ARC Test on GPT-4 deception – [Link](https://www.vice.com/en/article/bvmv7v/gpt-4-taskrabbit-openai)
 - ChaosGPT Case Study – [Link](https://www.vice.com/en/article/m7gz3n/chaosgpt)

--- a/tab_contributing.md
+++ b/tab_contributing.md
@@ -12,7 +12,7 @@ tags: AITG
 The OWASP projects are an open source effort, and we enthusiastically welcome all forms of contributions and feedback.
 
 - 📥 Send your suggestion, propose your concepts to the [project leader](mailto:matteo.meucci@owasp.org).
-- 👋 Join OWASP in our [Slack]() workspace.
+- 👋 Join OWASP in our [Slack](https://owasp.org/slack/invite) workspace.
 - Start contributing here: [OWASP AI Testing Guide Table of Contents](https://github.com/OWASP/www-project-ai-testing-guide/blob/main/Document/README.md)
 
 ### Project Lead


### PR DESCRIPTION
## Summary

This PR fixes empty and outdated reference links in the project documentation:

1. **`tab_contributing.md`**: Fixed missing OWASP Slack workspace invite link (`[Slack]()` -> `[Slack](https://owasp.org/slack/invite)`).
2. **`Document/content/tests/AITG-APP-06_Testing_for_Agentic_Behavior_Limits.md`**:
   - Fixed empty link for **OWASP Top 10 for Agentic Applications** to point to the official OWASP Agent Security Initiative repository path.
   - Updated **LLM06 (Excessive Agency)** reference URL to the official 2025 GenAI risk page (`https://genai.owasp.org/llmrisk/llm062025-excessive-agency/`) and removed leftover URL parameters.

## Changes Made
- `tab_contributing.md`: Added OWASP Slack invite URL.
- `Document/content/tests/AITG-APP-06_Testing_for_Agentic_Behavior_Limits.md`: Corrected LLM06 URL and added Agentic Top 10 link.

All links were tested and verified.